### PR TITLE
Clean up kanjidic context

### DIFF
--- a/cjktools/common.py
+++ b/cjktools/common.py
@@ -109,20 +109,4 @@ class _NullContextWrapper(object):
 try:
     from contextlib import ExitStack as _ExitStack
 except ImportError:
-    # There is a bug in contextlib2 that prevents its use with StreamReaders
-    # So we need to subclass for now until we can pin to a version where it's
-    # fixed. See https://github.com/ncoghlan/contextlib2/issues/5
-    from contextlib2 import ExitStack as bExitStack
-
-    class _ExitStack(bExitStack):
-        def enter_context(self, cm):
-            try:
-                return super(_ExitStack, self).enter_context(cm)
-            except AttributeError as e:
-                _cm_type = cm.__class__
-                _exit = _cm_type.__exit__
-                result = _cm_type.__enter__(cm)
-
-
-            self._push_cm_exit(cm, _exit)
-            return result
+    from contextlib2 import ExitStack as _ExitStack

--- a/cjktools/resources/kanjidic.py
+++ b/cjktools/resources/kanjidic.py
@@ -14,6 +14,7 @@ from itertools import chain
 
 from cjktools import scripts
 from cjktools.common import sopen
+from cjktools.common import _ExitStack as ExitStack
 
 from functools import reduce
 
@@ -101,8 +102,12 @@ class Kanjidic(dict):
                 cjkdata.get_resource('kanjd212'),
             ]
 
-        line_stream = reduce(chain, [sopen(f, mode='r') for f in kanjidic_files])
-        self._parse_kanjidic(line_stream)
+        with ExitStack() as stack:
+            file_chain = (stack.enter_context(sopen(f, mode='r'))
+                          for f in kanjidic_files)
+            line_stream = reduce(chain, file_chain)
+
+            self._parse_kanjidic(line_stream)
 
     @classmethod
     def get_cached(cls):

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ REQUIRES = ['six']
 if sys.version_info < (3, 4, 0):
     REQUIRES.append('enum34')
 
+# For Python <= 3.3 we need to pull in the backport of ExitStack
+if sys.version_info < (3, 3, 0):
+    REQUIRES.append('contextlib2')
+
 # Set up the classifiers
 CLASSIFIERS = [
     'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 4, 0):
 
 # For Python <= 3.3 we need to pull in the backport of ExitStack
 if sys.version_info < (3, 3, 0):
-    REQUIRES.append('contextlib2')
+    REQUIRES.append('contextlib2>=0.5.3')
 
 # Set up the classifiers
 CLASSIFIERS = [


### PR DESCRIPTION
Currently `cjktools.resources.kanjidic` leaves resources opened and doesn't use a context manager. This PR uses a (new in Python 3.3) `contextlib.ExitStack` context manager stack to handle the multiple contexts properly.

Because `ExitStack` is a 3.x only feature, this adds a new dependency, `contextlib2`, which is a backport of many features of the Python 3.x `contextlib`. <strike>Its `ExitStack`, however, evidently has a bug (see ncoghlan/contextlib2#5) that prevents its use with `StreamReader` and `StreamWriter` objects, so I've patched in a fix in `common`. If The bug gets fixed in `contextlib2`, I would just pin the fixed version as a minimum version in `setup.py` and drop my patch.</strike> (Bug has been fixed and released as 0.5.3, so I dropped the patch and pinned that as minimum version).

Oh, I should note that I forked this branch from #4. If you don't want to accept #4 but do want to accept this, let me know and I can refactor. I figured it's easier this way because I think there might end up being merge conflicts in `setup.py` if both are accepted.